### PR TITLE
amend homepage wording to comply with Arch Linux CoC

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,33 +31,29 @@
       <hr>
       <h2>about</h2>
       <p><strong>Xlibre</strong> is a fork of the Xorg Xserver with lots of
-      code cleanups and enhanced functionality.</p>
+      code cleanups, improvements, features, and enhanced functionality.</p>
 
-      <p><strong>This</strong> fork was necessary since toxic elements within
-      Xorg projects, moles from BigTech, are boycotting any substantial work on
-      Xorg, in order to destroy the project, to eliminate competition of their
-      own products. Classic "embrace, extend, extinguish" tactics.</p>
+      <p><strong>This</strong> fork was created because development progress on
+      the Xorg X server had largely stalled, with significant contributions
+      and improvements going unmerged for extended periods. Xlibre provides an
+      actively maintained environment where development can move forward.</p>
 
-      <p><strong>Right</strong> after journalists first began covering the
-      planned fork Xlibre, on June 6th 2025, Redhat employees started a purge
-      on the Xlibre founder's GitLab account on freedesktop.org: deleted the
-      git repo, tickets, merge requests, etc, and so fired the shot that the
-      whole world heard.</p>
+      <p><strong>Since</strong> new features and improvements were consistently
+      not being accepted upstream, the decision was made to fork the project
+      and continue development independently. Xlibre quickly gained attention
+      across the open-source community
+      and was accepted into many GNU/Linux and BSD distributions.</p>
 
-      <p><strong>This</strong> is an independent project, not at all affiliated
-      with BigTech or any of their subsidiaries or tax evasion tools, nor any
-      political activists groups, state actors, etc. It's explicitly free of
-      any "DEI" or similar discriminatory policies. Anybody who's treating
-      others nicely is welcomed.</p>
+      <p><strong>This</strong> is an independent, community-driven project
+      without any corporate affiliation. Anybody who treats others with respect
+      is welcome.</p>
 
-      <p><strong>It doesn't</strong> matter which country you're coming from,
-      your political views, your race, your sex, your age, your food menu,
-      whether you wear boots or heels, whether you're furry or fairy, Conan or
-      McKay, comic character, a small furry creature from Alpha Centauri, or
-      just a boring average person. Anybody who's interested in bringing X
-      forward is welcome.</p>
+      <p><strong>It doesn't</strong> matter where you're from, what your
+      background is, your political views, your race, your sex, your age,
+      or how much experience you have.
+      If you're interested in moving X forward, there's a place for you here.</p>
 
-      <p><strong>Together we'll make X great again!</strong></p>
+      <p><strong>Together, let's move X forward again!</strong></p>
     </section>
 
     <section id="download">
@@ -129,10 +125,10 @@
       maintained and modernized alternative to the aging X11 system.</p>
 
       <p><strong>Q:</strong> Why was it forked?</p>
-      <p><strong>A:</strong> Xorg has been stifled by “toxic elements” and
-      “BigTech moles” blocking significant contributions. A classic “embrace,
-      extend, extinguish” pattern. Xlibre is presented as a pushback to
-      revitalize the codebase.</p>
+      <p><strong>A:</strong> Development on the Xorg X server had largely
+      stalled, with significant contributions and new features going unmerged for long periods.
+      Xlibre was created to pick up where Xorg left off and actively maintain
+      and improve the codebase.</p>
 
       <p><strong>Q:</strong> Who’s behind Xlibre?</p>
       <p><strong>A:</strong> The fork is led by Enrico Weigelt, previously a


### PR DESCRIPTION
Recently, the Arch Wiki removed the Xlibre page, citing the project's homepage as violating its Code of Conduct.

https://terms.archlinux.org/docs/code-of-conduct/

You can argue the homepage contains hostile language toward the Xorg Foundation and freedesktop.org. Major distros may use that as justification to exclude Xlibre. 

An Arch Wiki admin said that if the homepage is edited, the Wiki page could be restored.

<img width="400"  alt="Screenshot_20260418" src="https://github.com/user-attachments/assets/3e1f4015-98f6-4826-ae82-35e85143dc06" />

